### PR TITLE
Minor recipe improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 env:
    global:
      - CONAN_REFERENCE: "jsonformoderncpp/2.1.1"
-     - CONAN_USERNAME: "conan"
-     - CONAN_LOGIN_USERNAME: "vthiery"
+     - CONAN_USERNAME: "vthiery"
      - CONAN_CHANNEL: "stable"
      - CONAN_UPLOAD: "https://api.bintray.com/conan/vthiery/conan-packages"
 
@@ -13,12 +12,13 @@ linux: &linux
    python: "3.6"
    services:
      - docker
+
 osx: &osx
    os: osx
    language: generic
+
 matrix:
    include:
-
       - <<: *linux
         env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54
       - <<: *linux

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Vincent Thiery (vjmthiery@gmail.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/conanfile.py
+++ b/conanfile.py
@@ -4,18 +4,17 @@ from conans.tools import download
 class JsonForModernCppConan(ConanFile):
     name = "jsonformoderncpp"
     version = "2.1.1"
+    description = "JSON for Modern C++ parser and generator from https://github.com/nlohmann/json"
     license = "MIT"
     url = "https://github.com/vthiery/conan-jsonformoderncpp"
     author = "Vincent Thiery (vjmthiery@gmail.com)"
-    settings = None
-    options = {"path": "ANY"}
-    default_options = "path="
 
     def source(self):
         download("https://github.com/nlohmann/json/releases/download/v%s/json.hpp" % self.version, "json.hpp")
 
     def package(self):
-        header_dir = "include"
-        if self.options.path != "":
-            header_dir += "/" + str(self.options.path)
-        self.copy("*.hpp", dst=header_dir)
+        self.copy("*.hpp", dst="include")
+
+    def package_info(self):
+        self.cpp_info.libdirs = []
+        self.cpp_info.bindirs = []

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -12,10 +12,10 @@ class JsonForModernCppTestConan(ConanFile):
     generators = "cmake"
 
     def build(self):
-        cmake = CMake(self.settings)
+        cmake = CMake(self)
         # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is in "test_package"
-        cmake.configure(self, source_dir=self.conanfile_directory, build_dir="./")
-        cmake.build(self)
+        cmake.configure(source_dir=self.conanfile_directory, build_dir="./")
+        cmake.build()
 
     def test(self):
         os.chdir("bin")


### PR DESCRIPTION
- Added description
- Removed the PATH option. I think I understand why it was there, but are you sure it is really necessary? It will package the header in a different path, which will not be defined by the ``package_info()`` and thus not being found. Moreover, a different package ID will be generated for each different path, which is confusing, because it is a header only
- Removed the default bin/lib dirs. This will be added to the default template for headers in ``conan new`` and in the conan docs.
- Updated the CMake usage in test_package, to remove deprecation warnings.