### PR TITLE
Explicitly list the allowed versions of compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,7 @@ osx: &osx
 matrix:
    include:
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54
-      - <<: *linux
         env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
 
 install:
   - ./.travis/install.sh

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,6 +8,17 @@ class JsonForModernCppConan(ConanFile):
     license = "MIT"
     url = "https://github.com/vthiery/conan-jsonformoderncpp"
     author = "Vincent Thiery (vjmthiery@gmail.com)"
+    settings = "compiler"
+
+    def configure(self):
+        if self.settings.compiler == "gcc" and not str(self.settings.compiler.version) in ["4.9", "5.3", "5.4", "6.1", "6.2", "6.3"]:
+            raise Exception("Old gcc < 4.9 versions are not supported")
+        if self.settings.compiler == "Visual Studio" and not str(self.settings.compiler.version) in ["14", "15"]:
+            raise Exception("Old Visual Studio < 14 versions are not supported")
+        if self.settings.compiler == "clang" and not str(self.settings.compiler.version) in ["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0"]:
+            raise Exception("Old clang < 3.4 versions are not supported")
+        if self.settings.compiler == "apple-clang" and not str(self.settings.compiler.version) in ["6.4", "7.0", "7.3", "8.0", "8.1", "8.2", "8.3"]:
+            raise Exception("Old apple-clang < 6.4 versions are not supported")
 
     def source(self):
         download("https://github.com/nlohmann/json/releases/download/v%s/json.hpp" % self.version, "json.hpp")


### PR DESCRIPTION
The goal of this PR is to fix #2 .
The sets of allowed compilers are now reduced to the list given here: [supported-compilers](https://github.com/nlohmann/json#supported-compilers). I find the declaration of compiler versions a bit verbose, so feel free to advise on best practices here!

I also reduced the travis build matrix as the packaged library is header-only. 