### PR TITLE
add License

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile
+from conans import ConanFile, tools
 from conans.tools import download
 
 class JsonForModernCppConan(ConanFile):
@@ -12,8 +12,16 @@ class JsonForModernCppConan(ConanFile):
     def source(self):
         download("https://github.com/nlohmann/json/releases/download/v%s/json.hpp" % self.version, "json.hpp")
 
+    def build(self):
+        # as there is no LICENSE file, lets extract and generate it.
+        # It is useful for package consumers, so they can collect all license from all dependencies
+        tmp = tools.load("json.hpp")
+        license_contents = tmp[2:tmp.find("*/", 1)]
+        tools.save("LICENSE", license_contents)
+
     def package(self):
         self.copy("*.hpp", dst="include")
+        self.copy("LICENSE")
 
     def package_info(self):
         self.cpp_info.libdirs = []


### PR DESCRIPTION
This is so the binary package contains a copy of the license, which right now is embedded in the hpp file, but it is nicer for users if it is a separate file, because with conan, they can collect all license from all dependencies easily.