### PR TITLE
Reduce build matrix as one build is enough

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,7 @@ osx: &osx
 matrix:
    include:
       - <<: *linux
-        env: CONAN_GCC_VERSIONS=5.4 CONAN_DOCKER_IMAGE=lasote/conangcc54
-      - <<: *linux
         env: CONAN_GCC_VERSIONS=6.3 CONAN_DOCKER_IMAGE=lasote/conangcc63
-      - <<: *linux
-        env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=lasote/conanclang40
 
 install:
   - ./.travis/install.sh


### PR DESCRIPTION
This reduce the travis build matrix as the packaged library is header-only.