### PR TITLE
Feature/3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 env:
    global:
-     - CONAN_REFERENCE: "jsonformoderncpp/2.1.1"
+     - CONAN_REFERENCE: "jsonformoderncpp/3.1.0"
      - CONAN_USERNAME: "vthiery"
      - CONAN_CHANNEL: "stable"
      - CONAN_UPLOAD: "https://api.bintray.com/conan/vthiery/conan-packages"

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,8 @@ from conans.tools import download
 
 class JsonForModernCppConan(ConanFile):
     name = "jsonformoderncpp"
-    version = "2.1.1"
+    version = "3.1.0"
+    homepage = "https://github.com/nlohmann/json"
     description = "JSON for Modern C++ parser and generator from https://github.com/nlohmann/json"
     license = "MIT"
     url = "https://github.com/vthiery/conan-jsonformoderncpp"

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,20 +1,15 @@
 from conans import ConanFile, CMake
 import os
 
-version = "2.1.1"
-channel = os.getenv("CONAN_CHANNEL", "stable")
-username = os.getenv("CONAN_USERNAME", "vthiery")
-
 
 class JsonForModernCppTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    requires = "jsonformoderncpp/%s@%s/%s" % (version, username, channel)
     generators = "cmake"
 
     def build(self):
         cmake = CMake(self)
         # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is in "test_package"
-        cmake.configure(source_dir=self.conanfile_directory, build_dir="./")
+        cmake.configure()
         cmake.build()
 
     def test(self):


### PR DESCRIPTION
fixes #10 

Some notes:
- Opened to master, but I guess that you want to open release/3.1.0
- Besides the version bump the only thing changed is the removal of ``conanfile_directory`` (deprecated in conan 1.0). I'll try to backport this fix to previous releases.

Thanks @nlohmann for updating about the release.