### PR TITLE
Release package 3.1.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,29 +1,23 @@
 from conans import ConanFile, tools
-from conans.tools import download
+import os
+
 
 class JsonForModernCppConan(ConanFile):
     name = "jsonformoderncpp"
     version = "3.1.0"
-    homepage = "https://github.com/nlohmann/json"
     description = "JSON for Modern C++ parser and generator from https://github.com/nlohmann/json"
     license = "MIT"
     url = "https://github.com/vthiery/conan-jsonformoderncpp"
+    repo_url = "https://github.com/nlohmann/json"
     author = "Vincent Thiery (vjmthiery@gmail.com)"
 
     def source(self):
-        download("https://github.com/nlohmann/json/releases/download/v%s/json.hpp" % self.version, "json.hpp")
+        tools.download("%s/blob/v%s/LICENSE.MIT" % (self.repo_url, self.version), "LICENSE.MIT")
 
-    def build(self):
-        # as there is no LICENSE file, lets extract and generate it.
-        # It is useful for package consumers, so they can collect all license from all dependencies
-        tmp = tools.load("json.hpp")
-        license_contents = tmp[2:tmp.find("*/", 1)]
-        tools.save("LICENSE", license_contents)
+        expected_hash = "2b7234fca394d1e27b7e017117ed80b7518fafbb4f4c13a7c069624f6f924673"
+        tools.get("%s/releases/download/v%s/include.zip" % (self.repo_url, self.version), sha256=expected_hash)
 
     def package(self):
-        self.copy("*.hpp", dst="include")
-        self.copy("LICENSE")
+        self.copy("*.hpp")
+        self.copy("LICENSE.MIT")
 
-    def package_info(self):
-        self.cpp_info.libdirs = []
-        self.cpp_info.bindirs = []

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,9 +1,11 @@
 project(PackageTest CXX)
-cmake_minimum_required(VERSION 3.0)
-add_compile_options(-std=c++11)
+cmake_minimum_required(VERSION 3.1.2)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-conan_basic_setup()
+conan_basic_setup(TARGETS)
 
 add_executable(example example.cpp)
-target_link_libraries(example ${CONAN_LIBS})
+target_link_libraries(example CONAN_PKG::jsonformoderncpp)

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,5 +1,6 @@
-#include "json.hpp"
 #include <iostream>
+
+#include <nlohmann/json.hpp>
 
 using nlohmann::json;
 


### PR DESCRIPTION
Hi,

I've updated the recipe for Json v3.1.0.
This release now includes a different way to install the project (multiple headers).

Users also have to `#include <nlohmann/json.hpp>`.

I've cleaned/updated a few parts of the recipe as well.