### PR TITLE
Package the library using cmake's install target

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,10 +1,11 @@
-from conans import ConanFile, tools
+from conans import ConanFile, CMake, tools
 import os
 
 
 class JsonForModernCppConan(ConanFile):
     name = "jsonformoderncpp"
     version = "3.1.1"
+    settings = "os", "compiler", "arch", "build_type"
     description = "JSON for Modern C++ parser and generator from https://github.com/nlohmann/json"
     license = "MIT"
     url = "https://github.com/vthiery/conan-jsonformoderncpp"
@@ -12,12 +13,17 @@ class JsonForModernCppConan(ConanFile):
     author = "Vincent Thiery (vjmthiery@gmail.com)"
 
     def source(self):
-        tools.download("%s/blob/v%s/LICENSE.MIT" % (self.repo_url, self.version), "LICENSE.MIT")
+        tools.get("%s/archive/v%s.zip" % (self.repo_url, self.version))
 
-        expected_hash = "fde771d4b9e4f222965c00758a2bdd627d04fb7b59e09b7f3d1965abdc848505"
-        tools.get("%s/releases/download/v%s/include.zip" % (self.repo_url, self.version), sha256=expected_hash)
+    def build(self):
+        cmake = CMake(self)
+        cmake.definitions["JSON_BuildTests"] = False
+        cmake.definitions["JSON_MultipleHeaders"] = True
+        cmake.configure(source_folder="json-%s" % self.version)
+        cmake.install()
 
     def package(self):
-        self.copy("*.hpp")
-        self.copy("LICENSE.MIT")
+        self.copy("LICENSE.MIT", src="json-%s" % self.version)
 
+    def package_id(self):
+        self.info.header_only()


### PR DESCRIPTION
Implements the change proposed in #16.

Performed changes:
* Download a full repository snapshot instead of only the headers. Unfortunately, these snapshots are not generated at release time but on request by GitHub which means that verifying the checksum is [not a good idea](https://github.com/libgit2/libgit2/issues/4343).
* Package the library via the install target generated by cmake. This automatically also installs the files I requested in #16.
* Install the `LICENSE.MIT` file from the source snapshot instead of the HTML file downloaded from GitHub. I assume packaging the HTML file was a bug and not on purpose.
* Adds the common package settings to make the CMake helper usable. The `package_id` method then is used to ensure that only one package exists independent of the actual settings.

I do not particularly like the addition of the settings just to workaround some (in this case) pointless errors from the CMake helper. However, I still prefer to use the helper for readability reasons.

@memsharded For the future, do you think that it makes sense to change the CMake helper such that it can be used without settings or should we settle with the current behavior. Note that I already stumbled across a similar problems when I played with conan's current [cross compiling support](https://github.com/conan-io/conan/issues/2301#issuecomment-358742357).
 